### PR TITLE
Stop using adsrc column

### DIFF
--- a/adminer/drivers/pgsql.inc.php
+++ b/adminer/drivers/pgsql.inc.php
@@ -352,7 +352,7 @@ WHERE relkind IN ('r', 'm', 'v', 'f')
 
 		$identity_column = min_version(10) ? "(a.attidentity = 'd')::int" : '0';
 
-		foreach (get_rows("SELECT a.attname AS field, format_type(a.atttypid, a.atttypmod) AS full_type, d.adsrc AS default, a.attnotnull::int, col_description(c.oid, a.attnum) AS comment, $identity_column AS identity
+		foreach (get_rows("SELECT a.attname AS field, format_type(a.atttypid, a.atttypmod) AS full_type, pg_get_expr(d.adbin, d.adrelid) AS default, a.attnotnull::int, col_description(c.oid, a.attnum) AS comment, $identity_column AS identity
 FROM pg_class c
 JOIN pg_namespace n ON c.relnamespace = n.oid
 JOIN pg_attribute a ON c.oid = a.attrelid


### PR DESCRIPTION
Was removed in V12, invalid since V8.

See https://www.postgresql.org/docs/8.3/catalog-pg-attrdef.html